### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Run tests with coverage
         run: npx jest --coverage
 
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v6
         env:


### PR DESCRIPTION
Adding a new report uploading action to the workflow to preserve reports even after the workflow is resolved so they can be later accessed for more details. Should be able to be found in the Actions, then the specific workflow, under Artifacts as coverage-report.zip
Closes #186 