### PR TITLE
Fix: Preserve accessible toggle state during multi-segment trips

### DIFF
--- a/app/CampusMapScreen.tsx
+++ b/app/CampusMapScreen.tsx
@@ -510,14 +510,6 @@ export default function CampusMapScreen() {
 
   const poiSearchLocation = userLocation ?? CAMPUSES[currentCampus].coordinates;
 
-  const activePOICategoryKey = useMemo(
-    () =>
-      Array.from(activePOICategories)
-        .sort((a, b) => a.localeCompare(b))
-        .join(","),
-    [activePOICategories],
-  );
-
   const task15Snapshot = useRef<Task15Snapshot | null>(null);
   const wasPOIListOpenRef = useRef(false);
 


### PR DESCRIPTION
- Set accessibleOnly state from transitionPayload when receiving indoor-to-outdoor transition
- This ensures the accessibility preference persists when navigating from outdoor segment to the next indoor segment

The fix preserves the user's accessibility preference throughout the entire indoor to outdoor to indoor trip flow.

Closes #329