### PR TITLE
Fix: Add padding on Android to avoid content overlap with navigation bar

### DIFF
--- a/__tests__/CampusMapScreen.test.tsx
+++ b/__tests__/CampusMapScreen.test.tsx
@@ -1,4 +1,9 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
+jest.mock("react-native-safe-area-context", () => ({
+  SafeAreaProvider: ({ children }: any) => children,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
 jest.mock("@react-native-firebase/analytics", () => () => ({
   logEvent: jest.fn(() => Promise.resolve()),
   setAnalyticsCollectionEnabled: jest.fn(() => Promise.resolve()),

--- a/__tests__/CampusMapScreenPOI.test.tsx
+++ b/__tests__/CampusMapScreenPOI.test.tsx
@@ -6,6 +6,10 @@ import React from "react";
 import CampusMapScreen from "../app/CampusMapScreen";
 import { useNearbyPOIs } from "../hooks/useNearbyPOIs";
 
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
 let mockShouldResolveUserLocation = true;
 
 jest.mock("@expo/vector-icons", () => {

--- a/__tests__/DirectionStepsPanel.test.tsx
+++ b/__tests__/DirectionStepsPanel.test.tsx
@@ -8,6 +8,10 @@ import { createStyles } from "../styles/DirectionStepsPanel.styles";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { Text } = require("react-native");
 
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
 // Updated mock to render icon names, allowing us to test "bus" vs "walk" icons
 jest.mock("@expo/vector-icons", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/__tests__/_layout.test.tsx
+++ b/__tests__/_layout.test.tsx
@@ -3,6 +3,18 @@ import Constants from "expo-constants";
 import React from "react";
 import RootLayout from "../app/_layout";
 
+// Mock react-native-safe-area-context
+jest.mock("react-native-safe-area-context", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { View } = require("react-native");
+  return {
+    SafeAreaProvider: ({ children }: any) => <View>{children}</View>,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
 // Mock expo-constants
 jest.mock("expo-constants", () => ({
   __esModule: true,

--- a/__tests__/useBottomInset.test.ts
+++ b/__tests__/useBottomInset.test.ts
@@ -1,0 +1,39 @@
+import { Platform } from "react-native";
+import { renderHook } from "@testing-library/react-native";
+import { useBottomInset } from "../hooks/useBottomInset";
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: jest.fn(() => ({ top: 0, bottom: 24, left: 0, right: 0 })),
+}));
+
+describe("useBottomInset", () => {
+  const originalPlatform = Platform.OS;
+
+  afterEach(() => {
+    Object.defineProperty(Platform, "OS", { value: originalPlatform });
+  });
+
+  it("returns bottom inset plus additional padding on Android", () => {
+    Object.defineProperty(Platform, "OS", { value: "android" });
+    const { result } = renderHook(() => useBottomInset(10));
+    expect(result.current).toBe(34);
+  });
+
+  it("returns only additional padding on iOS", () => {
+    Object.defineProperty(Platform, "OS", { value: "ios" });
+    const { result } = renderHook(() => useBottomInset(10));
+    expect(result.current).toBe(10);
+  });
+
+  it("returns just bottom inset when no additional padding specified on Android", () => {
+    Object.defineProperty(Platform, "OS", { value: "android" });
+    const { result } = renderHook(() => useBottomInset());
+    expect(result.current).toBe(24);
+  });
+
+  it("returns 0 when no additional padding specified on iOS", () => {
+    Object.defineProperty(Platform, "OS", { value: "ios" });
+    const { result } = renderHook(() => useBottomInset());
+    expect(result.current).toBe(0);
+  });
+});

--- a/app/CampusMapScreen.tsx
+++ b/app/CampusMapScreen.tsx
@@ -24,6 +24,7 @@ import { WALKING_STRATEGY } from "../constants/strategies";
 import { spacing } from "../constants/theme";
 import { Buildings, RouteStep, ScheduleItem } from "../constants/type";
 import { useColorAccessibility } from "../contexts/ColorAccessibilityContext";
+import { useBottomInset } from "../hooks/useBottomInset";
 import { useNearbyPOIs } from "../hooks/useNearbyPOIs";
 import { useShuttleAvailability } from "../hooks/useShuttleAvailability";
 import type { PlacePOI } from "../services/GooglePlacesService";
@@ -347,6 +348,7 @@ type Task16Snapshot = {
 export default function CampusMapScreen() {
   const { colors } = useColorAccessibility();
   const styles = useMemo(() => createStyles(colors), [colors]);
+  const bottomInset = useBottomInset();
   const [accessibleOnly, setAccessibleOnly] = useState(false);
   const { campus, transition, destinationRoomQuery } = useLocalSearchParams<{
     campus?: CampusKey;
@@ -1774,7 +1776,7 @@ export default function CampusMapScreen() {
 
       {/* Left button stack */}
       <View
-        style={[styles.buttonStack, { left: spacing.md, right: undefined }]}
+        style={[styles.buttonStack, { left: spacing.md, right: undefined, bottom: 50 + bottomInset }]}
       >
         <Pressable
           testID="show-shuttle-button"
@@ -1831,7 +1833,7 @@ export default function CampusMapScreen() {
       </View>
 
       {/* Right button stack */}
-      <View style={styles.buttonStack}>
+      <View style={[styles.buttonStack, { bottom: 50 + bottomInset }]}>
         <Pressable
           testID="poi-filter-button"
           accessibilityLabel={

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,7 @@
 import Constants from "expo-constants";
 import { Stack } from "expo-router";
 import { useCallback, useEffect, useRef } from "react";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import {
     resetSession,
     USABILITY_TESTING_ENABLED,
@@ -87,8 +88,10 @@ export default function RootLayout() {
   }, []);
 
   return (
-    <ColorAccessibilityProvider>
-      <AppStack onStateChange={handleStateChange} />
-    </ColorAccessibilityProvider>
+    <SafeAreaProvider>
+      <ColorAccessibilityProvider>
+        <AppStack onStateChange={handleStateChange} />
+      </ColorAccessibilityProvider>
+    </SafeAreaProvider>
   );
 }

--- a/components/DirectionStepsPanel.tsx
+++ b/components/DirectionStepsPanel.tsx
@@ -1,8 +1,10 @@
 import { MaterialCommunityIcons, MaterialIcons } from "@expo/vector-icons";
 import React from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
+import { spacing } from "../constants/theme";
 import { RouteStep } from "../constants/type";
 import { useColorAccessibility } from "../contexts/ColorAccessibilityContext";
+import { useBottomInset } from "../hooks/useBottomInset";
 import { RouteStrategy } from "../services/Routing";
 import { createStyles } from "../styles/DirectionStepsPanel.styles";
 
@@ -56,11 +58,12 @@ export function DirectionStepsPanel({
 }: DirectionStepsPanelProps) {
   const { colors } = useColorAccessibility();
   const styles = React.useMemo(() => createStyles(colors), [colors]);
+  const bottomInset = useBottomInset();
 
   if (steps.length === 0) return null;
 
   return (
-    <View style={styles.panel} pointerEvents="box-none">
+    <View style={[styles.panel, { bottom: spacing.lg + spacing.md + bottomInset }]} pointerEvents="box-none">
       <View style={styles.card}>
         <View style={styles.header}>
           <View style={styles.modeBadge}>

--- a/hooks/useBottomInset.ts
+++ b/hooks/useBottomInset.ts
@@ -1,0 +1,8 @@
+import { Platform } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+export function useBottomInset(additionalPadding: number = 0): number {
+  const insets = useSafeAreaInsets();
+  const bottomInset = Platform.OS === "android" ? insets.bottom : 0;
+  return bottomInset + additionalPadding;
+}


### PR DESCRIPTION
- Wrap app in SafeAreaProvider in _layout.tsx
- Create useBottomInset hook to get Android navigation bar height
- Apply bottom inset to CampusMapScreen button stacks
- Apply bottom inset to DirectionStepsPanel
- Add tests for useBottomInset hook
- Update test mocks for react-native-safe-area-context

This ensures all bottom UI elements are positioned above the Android navigation bar on devices with gesture navigation or floating nav bars.

Fixes #307