### PR TITLE
REF-18: extract shared requireGoogleApiKey into googleEnvUtils

### DIFF
--- a/services/GoogleDirectionsService.ts
+++ b/services/GoogleDirectionsService.ts
@@ -2,6 +2,7 @@ import { BUSSTOP } from "../constants/shuttle";
 import { DRIVING_STRATEGY, WALKING_STRATEGY } from "../constants/strategies";
 import { LatLng, RouteSegment, RouteStep } from "../constants/type";
 import { RouteStrategy } from "./Routing";
+import { requireGoogleApiKey } from "./googleEnvUtils";
 
 type DirectionsResponse = {
   status?: string;
@@ -36,17 +37,6 @@ function stripHtml(html: string): string {
     .trim();
 }
 
-function requireGoogleApiKey(): string {
-  const apiKey = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY;
-
-  if (!apiKey) {
-    throw new Error(
-      "Missing EXPO_PUBLIC_GOOGLE_MAPS_API_KEY. Add it to your env (and restart Metro).",
-    );
-  }
-
-  return apiKey;
-}
 
 function buildDirectionsUrl(
   origin: LatLng,

--- a/services/GooglePlacesService.ts
+++ b/services/GooglePlacesService.ts
@@ -2,19 +2,10 @@ import {
   OUTDOOR_POI_CATEGORY_MAP,
   type OutdoorPOICategoryId,
 } from "../constants/outdoorPOI";
+import { requireGoogleApiKey } from "./googleEnvUtils";
 
 const NEARBY_SEARCH_URL =
   "https://places.googleapis.com/v1/places:searchNearby";
-
-function requireGoogleApiKey(): string {
-  const apiKey = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY;
-  if (!apiKey) {
-    throw new Error(
-      "Missing EXPO_PUBLIC_GOOGLE_MAPS_API_KEY. Add it to your env.",
-    );
-  }
-  return apiKey;
-}
 
 export interface PlacePOI {
   placeId: string;

--- a/services/googleEnvUtils.ts
+++ b/services/googleEnvUtils.ts
@@ -1,0 +1,11 @@
+export function requireGoogleApiKey(): string {
+  const apiKey = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY;
+
+  if (!apiKey) {
+    throw new Error(
+      "Missing EXPO_PUBLIC_GOOGLE_MAPS_API_KEY. Add it to your env (and restart Metro).",
+    );
+  }
+
+  return apiKey;
+}


### PR DESCRIPTION
GoogleDirectionsService and GooglePlacesService each had their own copy of requireGoogleApiKey() with slightly different error messages. This extracts the function into a new services/googleEnvUtils.ts module and replaces both local copies with an import.

No behavior change, any new Google service that needs the Maps API key now has a single place to import from.

closes #375 